### PR TITLE
Docs work

### DIFF
--- a/docs/twoslash/.gitignore
+++ b/docs/twoslash/.gitignore
@@ -19,3 +19,5 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+content/docs/changelog.md

--- a/docs/twoslash/.gitignore
+++ b/docs/twoslash/.gitignore
@@ -20,4 +20,4 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
-content/docs/changelog.md
+src/content/docs/getting-started/changelog.md

--- a/docs/twoslash/package.json
+++ b/docs/twoslash/package.json
@@ -4,11 +4,12 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "astro dev",
+		"dev": "pnpm make-changelog && astro dev",
 		"start": "astro dev",
-		"build": "astro build",
+		"build": "pnpm make-changelog && astro build",
 		"preview": "astro preview",
-		"astro": "astro"
+		"astro": "astro",
+		"make-changelog": "tsm --require=./scripts/lib/filter-warnings.cjs ./scripts/changelog.ts"
 	},
 	"dependencies": {
 		"@astrojs/starlight": "^0.29.0",
@@ -18,7 +19,13 @@
 		"sharp": "^0.33.5",
 		"expressive-code-twoslash": "workspace:*",
 		"starlight-package-managers": "^0.8.0",
-		"rehype-expressive-code": "^0.38.3"
+		"rehype-expressive-code": "^0.38.3",
+		"mdast-util-to-markdown": "^2.1.2",
+		"mdast-util-to-string": "4.0.0",
+		"mdast-util-from-markdown": "^2.0.2",
+		"mdast": "^3.0.0",
+		"@types/mdast": "^4.0.4",
+		"unist-util-visit": "^5.0.0"
 	},
 	"devDependencies": {
 		"@astrojs/check": "^0.9.4",

--- a/docs/twoslash/scripts/changelog.ts
+++ b/docs/twoslash/scripts/changelog.ts
@@ -13,6 +13,7 @@ output.push(
 	'---',
 	'# Warning: This file is generated automatically. Do not edit!',
 	'title: Release Notes',
+	'editUrl: false',
     'sideBar:',
     '  order: 3',
 	'---',

--- a/docs/twoslash/scripts/changelog.ts
+++ b/docs/twoslash/scripts/changelog.ts
@@ -1,0 +1,57 @@
+import { toMarkdown } from 'mdast-util-to-markdown'
+import type { List, Root } from 'mdast'
+import { loadChangelog, semverCategories } from './lib/changelogs'
+import { writeFileLines } from './lib/utils'
+
+const changelog = loadChangelog('../../packages/twoslash/CHANGELOG.md')
+
+// Generate markdown output
+const output: string[] = []
+
+output.push(
+	// Add release notes frontmatter to output
+	'---',
+	'# Warning: This file is generated automatically. Do not edit!',
+	'title: Release Notes',
+    'sideBar:',
+    '  order: 3',
+	'---',
+	'',
+    'This document contains release notes for the `expressive-code-twoslash` package.',
+    'For more information, see the [CHANGELOG file](https://github.com/MatthiesenXYZ/EC-Plugins/blob/main/packages/twoslash/CHANGELOG.md)',
+	''
+)
+
+const ast: Root = {
+	type: 'root',
+	children: [],
+}
+
+changelog.versions.forEach((version) => {
+	const versionChanges: List = { type: 'list', children: [] }
+	semverCategories.forEach((semverCategory) => {
+		version.changes[semverCategory].children.forEach((listItem) => {
+			versionChanges.children.push(listItem)
+		})
+	})
+	if (version.includes.size) {
+		versionChanges.children.push({
+			type: 'listItem',
+			children: [
+				{
+					type: 'paragraph',
+					children: [{ type: 'text', value: `Includes: ${[...version.includes].join(', ')} ` }],
+				},
+			],
+		})
+	}
+	if (!versionChanges.children.length) return
+
+	ast.children.push({ type: 'heading', depth: 2, children: [{ type: 'text', value: version.version }] })
+	ast.children.push(versionChanges)
+})
+
+output.push(toMarkdown(ast, { bullet: '-' }))
+
+// Write output to file
+writeFileLines('./src/content/docs/getting-started/changelog.md', output)

--- a/docs/twoslash/scripts/lib/changelogs.ts
+++ b/docs/twoslash/scripts/lib/changelogs.ts
@@ -1,0 +1,134 @@
+import { readdirSync, statSync, existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { fromMarkdown } from 'mdast-util-from-markdown'
+import { toString } from 'mdast-util-to-string'
+import { visit } from 'unist-util-visit'
+import type { List } from 'mdast'
+
+export type Changelog = {
+	packageName: string
+	versions: Version[]
+}
+
+export type Version = {
+	version: string
+	changes: { [key in SemverCategory]: List }
+	includes: Set<string>
+}
+
+export const semverCategories = ['major', 'minor', 'patch'] as const
+export type SemverCategory = (typeof semverCategories)[number]
+
+export function loadChangelog(path: string): Changelog {
+	let markdown = readFileSync(path, 'utf8')
+
+	// Convert GitHub usernames in "Thanks ..." sentences to links
+	markdown = markdown.replace(/(?<=Thank[^.!]*? )@([a-z0-9-]+)(?=[\s,.!])/gi, '[@$1](https://github.com/$1)')
+
+	const ast = fromMarkdown(markdown)
+	// const lines = readFileSync(path, 'utf8')
+	// 	.split(/\r?\n/)
+	// 	.map((line) => line.trimEnd())
+	const changelog: Changelog = {
+		packageName: '',
+		versions: [],
+	}
+	type ParserState = 'packageName' | 'version' | 'semverCategory' | 'changes'
+	let state: ParserState = 'packageName'
+	let version: Version | undefined
+	let semverCategory: SemverCategory | undefined
+
+	function handleNode(node: ReturnType<typeof fromMarkdown>['children'][number]) {
+		if (node.type === 'heading') {
+			if (node.depth === 1) {
+				if (state !== 'packageName') throw new Error('Unexpected h1')
+				changelog.packageName = toString(node)
+				state = 'version'
+				return
+			}
+			if (node.depth === 2) {
+				if (state === 'packageName') throw new Error('Unexpected h2')
+				version = {
+					version: toString(node),
+					changes: {
+						major: { type: 'list', children: [] },
+						minor: { type: 'list', children: [] },
+						patch: { type: 'list', children: [] },
+					},
+					includes: new Set<string>(),
+				}
+				changelog.versions.push(version)
+				state = 'semverCategory'
+				return
+			}
+			if (node.depth === 3) {
+				if (state === 'packageName' || state === 'version') throw new Error('Unexpected h3')
+				semverCategory = (toString(node).split(' ')[0] || '').toLowerCase() as SemverCategory
+				if (!semverCategories.includes(semverCategory)) throw new Error(`Unexpected semver category: ${semverCategory}`)
+				state = 'changes'
+				return
+			}
+		}
+		if (node.type === 'list') {
+			if (state !== 'changes' || !version || !semverCategory) throw new Error('Unexpected list')
+			// Go through list items
+			for (let listItemIdx = 0; listItemIdx < node.children.length; listItemIdx++) {
+				const listItem = node.children[listItemIdx]
+				if (!listItem) continue
+
+				// Check if the current list item ends with a nested sublist that consists
+				// of items matching the pattern `<some-package-name>@<version>`
+				const lastChild = listItem.children[listItem.children.length - 1]
+				if (lastChild?.type === 'list') {
+					const packageRefs: string[] = []
+					lastChild.children.forEach((subListItem) => {
+						const text = toString(subListItem)
+						if (parsePackageReference(text)) packageRefs.push(text)
+					})
+					if (packageRefs.length === lastChild.children.length) {
+						// If so, add the packages to `includes`
+						for (const packageRef of packageRefs) {
+							version.includes.add(packageRef)
+						}
+						// Remove the sub-list from the list item
+						listItem.children.pop()
+					}
+				}
+
+				const firstPara = listItem.children[0]?.type === 'paragraph' ? listItem.children[0] : undefined
+				if (firstPara) {
+					// Remove IDs like `bfed62a: ...` or `... [85dbab8]` from the first paragraph
+					visit(firstPara, 'text', (textNode) => {
+						textNode.value = textNode.value.replace(/(^[0-9a-f]{7,}: | \[[0-9a-f]{7,}\]$)/, '')
+					})
+					// Skip list items that only contain the text `Updated dependencies`
+					const firstParaText = toString(firstPara)
+					if (firstParaText === 'Updated dependencies') continue
+					// If the list item is a package reference, add it to `includes` instead
+					const packageRef = parsePackageReference(firstParaText)
+					if (packageRef) {
+						version.includes.add(firstParaText)
+						continue
+					}
+					// Add the list item to the changes
+					version.changes[semverCategory].children.push(listItem)
+				}
+			}
+			return
+		}
+		throw new Error(`Unexpected node: ${JSON.stringify(node)}`)
+	}
+
+	ast.children.forEach((node) => {
+		handleNode(node)
+	})
+
+	return changelog
+}
+
+function parsePackageReference(str: string) {
+	const matches = str.match(/^([@/a-z0-9-]+)@([0-9.]+)$/)
+	if (!matches) return
+	const [, packageName, version] = matches
+	return { packageName, version }
+}

--- a/docs/twoslash/scripts/lib/filter-warnings.cjs
+++ b/docs/twoslash/scripts/lib/filter-warnings.cjs
@@ -1,0 +1,19 @@
+/**
+ * When using custom loaders like `tsm` to add TypeScript & module support to scripts,
+ * Node.js outputs a known set of warnings, which distract from the actual script output.
+ *
+ * By adding `--require=./scripts/lib/filter-warnings.cjs` to the `node` or `tsm` args,
+ * this script filters those known warnings (but not any others) from the output.
+ */
+
+// Remove Node's built-in `warning` listener which outputs all warnings to stderr
+process.removeAllListeners('warning')
+
+// Add our own version that skips known warnings
+process.on('warning', (warning) => {
+	let { name, message } = warning
+	if (name === 'ExperimentalWarning' && (message.indexOf('--experimental-loader') > -1 || message.indexOf('Custom ESM Loaders') > -1)) return
+	if (name === 'DeprecationWarning' && message.indexOf('Obsolete loader hook') > -1) return
+
+	console.warn(warning)
+})

--- a/docs/twoslash/scripts/lib/utils.ts
+++ b/docs/twoslash/scripts/lib/utils.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import { EOL } from 'node:os'
+
+export function normalizeLineEndings(contents: string) {
+	return contents.replace(/\r\n/g, '\n')
+}
+
+export function splitLines(contents: string) {
+	return normalizeLineEndings(contents).split(/\n/)
+}
+
+export function readFileLines(filePath: string) {
+	return splitLines(fs.readFileSync(filePath, 'utf8'))
+}
+
+export function writeFileLines(filePath: string, lines: string | string[]) {
+	const normalizedLines = splitLines(Array.isArray(lines) ? lines.join('\n') : lines)
+	fs.writeFileSync(filePath, normalizedLines.join(EOL))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.29.0
         version: 0.29.0(astro@4.16.10(@types/node@20.17.1)(rollup@4.24.2)(typescript@5.6.3))
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       astro:
         specifier: ^4.16.10
         version: 4.16.10(@types/node@20.17.1)(rollup@4.24.2)(typescript@5.6.3)
@@ -50,6 +53,18 @@ importers:
       expressive-code-twoslash:
         specifier: workspace:*
         version: link:../../packages/twoslash
+      mdast:
+        specifier: ^3.0.0
+        version: 3.0.0
+      mdast-util-from-markdown:
+        specifier: ^2.0.2
+        version: 2.0.2
+      mdast-util-to-markdown:
+        specifier: ^2.1.2
+        version: 2.1.2
+      mdast-util-to-string:
+        specifier: 4.0.0
+        version: 4.0.0
       rehype-expressive-code:
         specifier: ^0.38.3
         version: 0.38.3
@@ -59,6 +74,9 @@ importers:
       starlight-package-managers:
         specifier: ^0.8.0
         version: 0.8.0(@astrojs/starlight@0.29.0(astro@4.16.10(@types/node@20.17.1)(rollup@4.24.2)(typescript@5.6.3)))(astro@4.16.10(@types/node@20.17.1)(rollup@4.24.2)(typescript@5.6.3))
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
@@ -2167,11 +2185,15 @@ packages:
   mdast-util-to-hast@13.2.0:
     resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
 
-  mdast-util-to-markdown@2.1.0:
-    resolution: {integrity: sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==}
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdast@3.0.0:
+    resolution: {integrity: sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==}
+    deprecated: '`mdast` was renamed to `remark`'
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3397,7 +3419,7 @@ snapshots:
       i18next: 23.16.4
       js-yaml: 4.1.0
       mdast-util-directive: 3.0.0
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
       pagefind: 1.1.1
       rehype: 13.0.2
@@ -5509,7 +5531,7 @@ snapshots:
       '@types/unist': 3.0.3
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.1
       stringify-entities: 4.0.4
       unist-util-visit-parents: 6.0.1
@@ -5553,7 +5575,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -5562,7 +5584,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5572,7 +5594,7 @@ snapshots:
       devlop: 1.1.0
       markdown-table: 3.0.4
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5581,7 +5603,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5593,7 +5615,7 @@ snapshots:
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5604,7 +5626,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5617,7 +5639,7 @@ snapshots:
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.1
       stringify-entities: 4.0.4
       unist-util-stringify-position: 4.0.0
@@ -5631,7 +5653,7 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.1.3
       mdast-util-mdxjs-esm: 2.0.1
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5642,7 +5664,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5663,13 +5685,14 @@ snapshots:
       unist-util-visit: 5.0.0
       vfile: 6.0.3
 
-  mdast-util-to-markdown@2.1.0:
+  mdast-util-to-markdown@2.1.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.1.0
       mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.0
       micromark-util-decode-string: 2.0.0
       unist-util-visit: 5.0.0
       zwitch: 2.0.4
@@ -5677,6 +5700,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdast@3.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -6363,7 +6388,7 @@ snapshots:
   remark-stringify@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
   request-light@0.5.8: {}


### PR DESCRIPTION
This pull request introduces a new changelog generation script and integrates it into the build and development processes. Additionally, it updates various dependencies and includes several utility functions to support the changelog generation.

### Changelog Generation:
* Added a new script `changelog.ts` to generate a markdown changelog file from the `CHANGELOG.md` file. (`docs/twoslash/scripts/changelog.ts`)
* Integrated the new changelog generation script into the `dev` and `build` scripts in `package.json`. (`docs/twoslash/package.json`)

### Dependency Updates:
* Updated `package.json` to include new dependencies required for the changelog script, such as `mdast-util-to-markdown`, `mdast-util-to-string`, `mdast-util-from-markdown`, `mdast`, `@types/mdast`, and `unist-util-visit`. (`docs/twoslash/package.json`)
* Updated `pnpm-lock.yaml` to reflect the new and updated dependencies. (`pnpm-lock.yaml`) [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR41-R43) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR56-R67) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR77-R79) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2170-R2197) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3400-R3422) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5512-R5534) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5556-R5578) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5565-R5587) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5575-R5597) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5584-R5606) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5596-R5618) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5607-R5629) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5620-R5642) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5634-R5656) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5645-R5667) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5666-R5695) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5704-R5705) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6366-R6391)

### Utility Functions:
* Added utility functions in `utils.ts` for normalizing line endings, splitting lines, reading file lines, and writing file lines. (`docs/twoslash/scripts/lib/utils.ts`)

### Warning Filtering:
* Added a script to filter known Node.js warnings when using custom loaders, improving the readability of script output. (`docs/twoslash/scripts/lib/filter-warnings.cjs`)

### .gitignore Update:
* Updated `.gitignore` to ignore the generated changelog file. (`docs/twoslash/.gitignore`)