### PR TITLE
Various simplifications, and cleanup.

### DIFF
--- a/.changeset/slimy-bugs-compare.md
+++ b/.changeset/slimy-bugs-compare.md
@@ -1,0 +1,10 @@
+---
+"expressive-code-twoslash": minor
+---
+
+Refactor code to be simpiler and small CSS tweaks
+
+- Add Twoslash includes map
+- Pass user defined Twoslash options to `createTwoslasher()`
+- Remove excess functions and move code back to main EC function
+- Add link color styles inside of Hover/Static docs

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -22,5 +22,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Thank you for submitting your Pull Request, the following links will become available for preview shortly:\n
-              - [`expressive-code-twoslash` Docs](https://${context.payload.pull_request.number}-twoslash.matthiesen.dev)
+              - [expressive-code-twoslash Docs](https://${context.payload.pull_request.number}-twoslash.matthiesen.dev)
+              `
             })

--- a/packages/twoslash/src/annotation.ts
+++ b/packages/twoslash/src/annotation.ts
@@ -172,15 +172,14 @@ export class TwoslashStaticAnnotation extends ExpressiveCodeAnnotation {
 	 * @param query - The query information for the node.
 	 */
 	constructor(
-		readonly hover: NodeHover,
+		readonly query: NodeQuery,
 		readonly line: ExpressiveCodeLine,
 		readonly includeJsDoc: boolean,
-		readonly query: NodeQuery,
 	) {
 		super({
 			inlineRange: {
 				columnStart: line.text.length,
-				columnEnd: line.text.length + hover.length,
+				columnEnd: line.text.length + query.length,
 			},
 		});
 	}
@@ -217,18 +216,18 @@ export class TwoslashStaticAnnotation extends ExpressiveCodeAnnotation {
 					},
 					[
 						h("div.twoslash-static-container.not-content", [
-							this.getHoverInfo(this.hover.text),
-							...(this.hover.docs && this.includeJsDoc
+							this.getHoverInfo(this.query.text),
+							...(this.query.docs && this.includeJsDoc
 								? [
 										h("div.twoslash-popup-docs", [
-											h("p", [renderMarkdown(this.hover.docs)]),
+											h("p", [renderMarkdown(this.query.docs)]),
 										]),
 									]
 								: []),
-							...(this.hover.tags && this.includeJsDoc
+							...(this.query.tags && this.includeJsDoc
 								? [
 										h("div.twoslash-popup-docs.twoslash-popup-docs-tags", [
-											...this.hover.tags.map((tag) =>
+											...this.query.tags.map((tag) =>
 												jsdocTags.includes(tag[0])
 													? h("p", [
 															h(

--- a/packages/twoslash/src/helpers.ts
+++ b/packages/twoslash/src/helpers.ts
@@ -57,6 +57,7 @@ export function renderMarkdown(md: string): ElementContent[] {
 	return (
 		toHast(mdast, {
 			handlers: {
+				// Replace this section with EC processing once it's available
 				// code: (state, node) => {
 				//     const lang = node.lang || '';
 				//     if (lang) {

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -1,0 +1,74 @@
+export class TwoslashIncludesManager {
+	constructor(public map: Map<string, string> = new Map()) {}
+
+	add(name: string, code: string): void {
+		const lines: string[] = [];
+
+		code.split("\n").forEach((l, _i) => {
+			const trimmed = l.trim();
+
+			if (trimmed.startsWith("// - ")) {
+				const key = trimmed.split("// - ")[1].split(" ")[0];
+				this.map.set(`${name}-${key}`, lines.join("\n"));
+			} else {
+				lines.push(l);
+			}
+		});
+		this.map.set(name, lines.join("\n"));
+	}
+
+	applyInclude(code: string): string {
+		const reMarker = /\/\/ @include: (.*)$/gm;
+
+		// Basically run a regex over the code replacing any // @include: thing with
+		// 'thing' from the map
+
+		const toReplace: [
+			index: number,
+			length: number,
+			replacementCode: string,
+		][] = [];
+
+		for (const match of code.matchAll(reMarker)) {
+			const key = match[1];
+			const replaceWith = this.map.get(key);
+
+			if (!replaceWith) {
+				const msg = `Could not find an include with the key: '${key}'.\nThere is: ${Array.from(this.map.keys())}.`;
+				throw new Error(msg);
+			}
+
+			toReplace.push([match.index, match[0].length, replaceWith]);
+		}
+
+		let newCode = code.toString();
+
+		// Go backwards through the found changes so that we can retain index position
+
+		for (const [index, length, replacementCode] of toReplace.reverse()) {
+			newCode =
+				newCode.slice(0, index) +
+				replacementCode +
+				newCode.slice(index + length);
+		}
+
+		return newCode;
+	}
+}
+
+/**
+ * An "include [name]" segment in a raw meta string has a "name" that is a sequence of word
+ * characters, possibly connected by dashes, that ends at a word boundary.
+ */
+const INCLUDE_META_REGEX = /include\s+([\w-]+)\b.*/;
+
+/**
+ * @param meta The raw meta string of a code block, e.g. 'twoslash include main-hello-world meta=miscellaneous'.
+ * @returns The name of the reusable code block, e.g. "main-hello-world", if it exists.
+ */
+export function parseIncludeMeta(meta?: string): string | null {
+	if (!meta) return null;
+
+	const match = meta.match(INCLUDE_META_REGEX);
+	return match?.[1] ?? null;
+}

--- a/packages/twoslash/src/index.ts
+++ b/packages/twoslash/src/index.ts
@@ -13,7 +13,9 @@ import {
 } from "./helpers";
 import popupModule from "./module-code/popup.min";
 import { getTwoSlashBaseStyles, twoSlashStyleSettings } from "./styles";
-import type { PluginTwoslashOptions } from "./types";
+import type { PluginTwoslashOptions, TwoSlashStyleSettings } from "./types";
+
+export type { PluginTwoslashOptions, TwoSlashStyleSettings };
 
 /**
  * Add Twoslash support to your Expressive Code TypeScript code blocks.

--- a/packages/twoslash/src/index.ts
+++ b/packages/twoslash/src/index.ts
@@ -44,7 +44,9 @@ export default function ecTwoSlash(
 	 *
 	 * @returns {Twoslasher} A new instance of the Twoslasher.
 	 */
-	const twoslasher = createTwoslasher();
+	const twoslasher = createTwoslasher({
+		...twoslashOptions,
+	});
 
 	const shouldTransform = buildMetaChecker(languages, explicitTrigger);
 

--- a/packages/twoslash/src/index.ts
+++ b/packages/twoslash/src/index.ts
@@ -1,21 +1,51 @@
 import { type ExpressiveCodePlugin, definePlugin } from "@expressive-code/core";
 import { createTwoslasher } from "twoslash";
 import {
-	addCompletionAnnotations,
-	addCustomTagAnnotations,
-	addErrorAnnotations,
-	addHighlightAnnotations,
-	addHoverOrStaticAnnotations,
 	buildMetaChecker,
 	checkForCustomTagsAndMerge,
-	ecTwoslasher,
-	replaceECBlockWithTwoslashBlock,
+	processCompletion,
+	splitCodeToLines,
+	compareNodes,
 } from "./helpers";
 import popupModule from "./module-code/popup.min";
 import { getTwoSlashBaseStyles, twoSlashStyleSettings } from "./styles";
 import type { PluginTwoslashOptions, TwoSlashStyleSettings } from "./types";
+import { parseIncludeMeta, TwoslashIncludesManager } from "./includes";
+import ts, { type CompilerOptions } from "typescript";
+import {
+	TwoslashCompletionAnnotation,
+	TwoslashCustomTagsAnnotation,
+	TwoslashErrorBoxAnnotation,
+	TwoslashErrorUnderlineAnnotation,
+	TwoslashHighlightAnnotation,
+	TwoslashHoverAnnotation,
+	TwoslashStaticAnnotation,
+} from "./annotation";
 
 export type { PluginTwoslashOptions, TwoSlashStyleSettings };
+
+/**
+ * Default TypeScript compiler options used in TwoSlash.
+ *
+ * @constant
+ * @type {CompilerOptions}
+ * @property {boolean} strict - Enable all strict type-checking options.
+ * @property {ts.ScriptTarget} target - Specify ECMAScript target version.
+ * @property {boolean} exactOptionalPropertyTypes - Ensure optional property types are exactly as declared.
+ * @property {boolean} downlevelIteration - Provide full support for iterables in ES5/ES3.
+ * @property {boolean} skipLibCheck - Skip type checking of declaration files.
+ * @property {string[]} lib - List of library files to be included in the compilation.
+ * @property {boolean} noEmit - Do not emit outputs.
+ */
+const defaultCompilerOptions: CompilerOptions = {
+	strict: true,
+	target: ts.ScriptTarget.ES2022,
+	exactOptionalPropertyTypes: true,
+	downlevelIteration: true,
+	skipLibCheck: true,
+	lib: ["ES2022", "DOM", "DOM.Iterable"],
+	noEmit: true,
+};
 
 /**
  * Add Twoslash support to your Expressive Code TypeScript code blocks.
@@ -52,6 +82,8 @@ export default function ecTwoSlash(
 
 	const shouldTransform = buildMetaChecker(languages, explicitTrigger);
 
+	const includesMap = new Map();
+
 	return definePlugin({
 		name: "expressive-code-twoslash",
 		jsModules: [popupModule],
@@ -60,37 +92,160 @@ export default function ecTwoSlash(
 		hooks: {
 			preprocessCode({ codeBlock }) {
 				if (shouldTransform(codeBlock)) {
-					// Run twoslash on the code block
-					const twoslash = ecTwoslasher(twoslasher, twoslashOptions, codeBlock);
+					// Create a new instance of the TwoslashIncludesManager
+					const includes = new TwoslashIncludesManager(includesMap);
 
-					// Hippo, I'm sorry for this function, but without it, the twoslash code
-					// overlays could find themselves in the wrong place of the codeblock
-					// depending on how much is going on in the code block.
+					// Apply the includes to the code block
+					const codeWithIncludes = includes.applyInclude(codeBlock.code);
 
-					// Most users should not need to worry about this, as it is only used in the
-					// codeblocks that have the `twoslash` meta tag, and this tag is configured as
-					// an explicit trigger in the plugin options by default.
+					// Parse the include meta
+					const include = parseIncludeMeta(codeBlock.meta);
 
-					// This hack simply replaces the existing codeblock lines with the twoslash code output.
-					// (This is how `shiki-twoslash` works, by REPLACING the shiki highlighter function with its own when active)
+					// Add the include to the includes map if it exists
+					if (include) includes.add(include, codeWithIncludes);
 
-					// Replace the EC code block with the twoslash code block
-					replaceECBlockWithTwoslashBlock(twoslash, codeBlock);
+					// Twoslash the code block
+					const twoslash = twoslasher(codeWithIncludes, codeBlock.language, {
+						...twoslashOptions,
+						compilerOptions: {
+							...defaultCompilerOptions,
+							...(twoslashOptions?.compilerOptions ?? {}),
+						},
+					});
 
-					// Generate the Hover and Static Annotations
-					addHoverOrStaticAnnotations(twoslash, codeBlock, includeJsDoc);
+					// Update EC code block with the twoslash information
+					if (twoslash.extension) {
+						codeBlock.language = twoslash.extension;
+					}
 
-					// Generate the Completion annotations
-					addCompletionAnnotations(twoslash, codeBlock);
+					// Get the EC and Twoslash code blocks
+					const ecCodeBlock = splitCodeToLines(codeWithIncludes);
+					const twoslashCodeBlock = splitCodeToLines(twoslash.code);
 
-					// Generate the Twoslash Highlight annotations
-					addHighlightAnnotations(twoslash, codeBlock);
+					// Replace the EC code block with the Twoslash code block
+					for (const line of twoslashCodeBlock) {
+						const ln = codeBlock.getLine(line.index);
+						if (ln) ln.editText(0, ln.text.length, line.line);
+					}
 
-					// Generate the error annotations
-					addErrorAnnotations(twoslash, codeBlock);
+					// Remove any extra lines from the EC code block
+					if (twoslashCodeBlock.length < ecCodeBlock.length) {
+						for (
+							let i = twoslashCodeBlock.length;
+							i < ecCodeBlock.length;
+							i++
+						) {
+							codeBlock.deleteLine(twoslashCodeBlock.length);
+						}
+					}
 
-					// Generate the Custom Tag annotations
-					addCustomTagAnnotations(twoslash, codeBlock);
+					// Process the Twoslash Error Annotations
+					for (const node of twoslash.errors) {
+						const line = codeBlock.getLine(node.line);
+
+						if (line) {
+							line.addAnnotation(new TwoslashErrorUnderlineAnnotation(node));
+							line.addAnnotation(new TwoslashErrorBoxAnnotation(node, line));
+						}
+					}
+
+					// Process the Twoslash Static (Query) Annotations
+					for (const node of twoslash.queries) {
+						const line = codeBlock.getLine(node.line);
+
+						if (line) {
+							line.addAnnotation(
+								new TwoslashStaticAnnotation(node, line, includeJsDoc),
+							);
+						}
+					}
+
+					// Process the Twoslash Highlight Annotations
+					for (const node of twoslash.highlights) {
+						const line = codeBlock.getLine(node.line);
+						if (line) {
+							line.addAnnotation(new TwoslashHighlightAnnotation(node));
+						}
+					}
+
+					// Process the Twoslash Hover Annotations
+					for (const node of twoslash.hovers) {
+						// Check if the node is already added as a static
+						const query = twoslash.queries.find((q) =>
+							compareNodes(q, node, { line: true, text: true }),
+						);
+
+						// Check if the node is already added as an error
+						const error = twoslash.errors.find((e) =>
+							compareNodes(e, node, {
+								line: true,
+								start: true,
+								length: true,
+								character: true,
+							}),
+						);
+
+						// Skip if the node is already added as a static or error annotation
+						if (query || error) {
+							continue;
+						}
+
+						const line = codeBlock.getLine(node.line);
+
+						if (line) {
+							line.addAnnotation(
+								new TwoslashHoverAnnotation(node, includeJsDoc),
+							);
+						}
+					}
+
+					// Process the Twoslash Completion Annotations
+					for (const node of twoslash.completions) {
+						// Process the completion item
+						const proccessed = processCompletion(node);
+						const line = codeBlock.getLine(node.line);
+
+						if (line) {
+							// Check if the node has a hover annotation
+							const currentHoverAnnotations = line
+								.getAnnotations()
+								.filter((a) => a instanceof TwoslashHoverAnnotation);
+
+							// Modify the inline range of the hover annotation
+							for (const annotation of currentHoverAnnotations) {
+								if (annotation.inlineRange) {
+									const { columnStart, columnEnd } = annotation.inlineRange;
+									if (
+										proccessed.startCharacter >= columnStart &&
+										proccessed.startCharacter <= columnEnd
+									) {
+										annotation.inlineRange.columnStart =
+											proccessed.startCharacter;
+									}
+								}
+
+								if (
+									annotation.hover.start === proccessed.startCharacter &&
+									annotation.hover.length === proccessed.length
+								) {
+									line.deleteAnnotation(annotation);
+								}
+							}
+
+							line.addAnnotation(
+								new TwoslashCompletionAnnotation(proccessed, node, line),
+							);
+						}
+					}
+
+					// Process the Twoslash Custom Tags Annotations
+					for (const node of twoslash.tags) {
+						const line = codeBlock.getLine(node.line);
+
+						if (line) {
+							line.addAnnotation(new TwoslashCustomTagsAnnotation(node, line));
+						}
+					}
 				}
 			},
 		},

--- a/packages/twoslash/src/styles.ts
+++ b/packages/twoslash/src/styles.ts
@@ -29,12 +29,18 @@ export const twoSlashStyleSettings = new PluginStyleSettings({
 				"transparent",
 			background: ({ theme }) => theme.colors["editor.background"] || theme.bg,
 			hoverUnderlineColor: ({ theme }) => theme.fg || "#888",
+			textColor: ({ theme }) => theme.colors["editor.foreground"] || theme.fg,
+
+			linkColor: ({ theme }) => theme.colors["terminal.ansiBrightBlue"],
+			linkColorVisited: ({ theme }) =>
+				theme.colors["terminal.ansiBrightMagenta"],
+			linkColorHover: ({ theme }) => theme.colors["terminal.ansiBrightCyan"],
+			linkColorActive: ({ theme }) => theme.colors["terminal.ansiBrightGreen"],
 
 			// Popup docs Extra styles
 			popupDocsMaxHeight: "200px",
 
 			// JS Doc Tag styles (`@param`, `@returns`, etc.)
-			// tagColorDark: ({ theme }) => theme.colors["terminal.ansiBlue"],
 			tagColor: ({ theme }) => theme.colors["terminal.ansiBrightBlue"],
 
 			// Temp styles till we can use the EC Code Engine to process
@@ -158,6 +164,23 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
             overflow-wrap: normal !important;
             width: max-content !important;
             margin-top: 0.5rem;
+            color: ${cssVar("twoSlash.textColor")};
+        }
+
+        .twoslash-popup-container a:link {
+            color: ${cssVar("twoSlash.linkColor")};
+        }
+
+        .twoslash-popup-container a:hover {
+            color: ${cssVar("twoSlash.linkColorHover")};
+        }
+
+        .twoslash-popup-container a:visited {
+            color: ${cssVar("twoSlash.linkColorVisited")};
+        }
+
+        .twoslash-popup-container a:active {
+            color: ${cssVar("twoSlash.linkColorActive")};
         }
 
         .twoslash-popup-container * {

--- a/packages/twoslash/src/styles.ts
+++ b/packages/twoslash/src/styles.ts
@@ -31,6 +31,7 @@ export const twoSlashStyleSettings = new PluginStyleSettings({
 			hoverUnderlineColor: ({ theme }) => theme.fg || "#888",
 			textColor: ({ theme }) => theme.colors["editor.foreground"] || theme.fg,
 
+			// Link styles
 			linkColor: ({ theme }) => theme.colors["terminal.ansiBrightBlue"],
 			linkColorVisited: ({ theme }) =>
 				theme.colors["terminal.ansiBrightMagenta"],
@@ -202,6 +203,22 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
             word-break: normal !important;
             overflow-wrap: normal !important;
             width: max-content !important;
+        }
+
+        .twoslash-static-container a:link {
+            color: ${cssVar("twoSlash.linkColor")};
+        }
+
+        .twoslash-static-container a:hover {
+            color: ${cssVar("twoSlash.linkColorHover")};
+        }
+
+        .twoslash-static-container a:visited {
+            color: ${cssVar("twoSlash.linkColorVisited")};
+        }
+
+        .twoslash-static-container a:active {
+            color: ${cssVar("twoSlash.linkColorActive")};
         }
 
         .twoslash-static-container:before {

--- a/packages/twoslash/src/types.ts
+++ b/packages/twoslash/src/types.ts
@@ -58,6 +58,11 @@ export interface TwoSlashStyleSettings {
 	borderColor: string;
 	background: string;
 	tagColor: string;
+	textColor: string;
+	linkColor: string;
+	linkColorHover: string;
+	linkColorVisited: string;
+	linkColorActive: string;
 	titleColor: string;
 	highlightBackground: string;
 	popupDocsMaxHeight: string;


### PR DESCRIPTION
This pull request includes a refactor to simplify the codebase and add new functionality for handling Twoslash includes. Key changes include the introduction of a new `TwoslashIncludesManager` class, modifications to the `TwoslashStaticAnnotation` class, and significant cleanup in the `helpers.ts` file.

### Refactoring and Simplification:

* Simplified `TwoslashStaticAnnotation` by replacing `hover` with `query` and updating related methods to use `query` instead of `hover`. (`packages/twoslash/src/annotation.ts`) [[1]](diffhunk://#diff-f2d1db62da819eaf05cf31d86c0772a524f7d6b8cdec02d05b8a5cddb0ed4063L175-R182) [[2]](diffhunk://#diff-f2d1db62da819eaf05cf31d86c0772a524f7d6b8cdec02d05b8a5cddb0ed4063L220-R230)
* Removed excess functions and moved code back to the main EC function. (`packages/twoslash/src/helpers.ts`) [[1]](diffhunk://#diff-3e3eb478cddd127f90f89a75a9adf7580ca0d0f729ef7bfbc8d58a7f33965bc5L242-L278) [[2]](diffhunk://#diff-3e3eb478cddd127f90f89a75a9adf7580ca0d0f729ef7bfbc8d58a7f33965bc5L332-R291) [[3]](diffhunk://#diff-3e3eb478cddd127f90f89a75a9adf7580ca0d0f729ef7bfbc8d58a7f33965bc5L479-L549)
* Added a new `TwoslashIncludesManager` class to manage includes and apply them to code. (`packages/twoslash/src/includes.ts`)

### Enhancements:

* Added functionality to pass user-defined Twoslash options to `createTwoslasher()`. (`packages/twoslash/src/index.ts`)
* Introduced a new function `compareNodes` to compare `TwoslashNode` objects based on specified criteria. (`packages/twoslash/src/helpers.ts`)

### CSS Tweaks:

* Added link color styles inside of Hover/Static docs. (`.changeset/slimy-bugs-compare.md`)