### PR TITLE
[Feat]: Add code processing to annotations

### DIFF
--- a/.changeset/pink-ants-deliver.md
+++ b/.changeset/pink-ants-deliver.md
@@ -1,0 +1,5 @@
+---
+"expressive-code-twoslash": patch
+---
+
+Add codeblock and type processing to Hover/Static annotations

--- a/packages/twoslash/README.md
+++ b/packages/twoslash/README.md
@@ -8,7 +8,6 @@ Add Twoslash support to your Expressive Code TypeScript code blocks.
 
 ### TODO
 - [ ] Make Annotations accessible
-- [ ] Implement Annotation code processesing (Requires support from EC (Planned))
 - [ ] Use EC's Markdown processing system once released. (Requires support from EC (Planned))
 - [ ] Figure out how to work with TwoslashVFS and setup support for "Showing Emitted Files"
 

--- a/packages/twoslash/package.json
+++ b/packages/twoslash/package.json
@@ -31,9 +31,7 @@
 		"default": "./dist/index.js"
 	},
 	"types": "./dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build-js-module": "tsm --require=../../scripts/filter-warnings.cjs ./scripts/minify.ts",
 		"compile": "tsup ./src/index.ts --format esm --dts --sourcemap --clean",
@@ -45,7 +43,8 @@
 		"mdast-util-from-markdown": "^2.0.2",
 		"mdast-util-gfm": "^3.0.0",
 		"mdast-util-to-hast": "^13.2.0",
-		"twoslash": "^0.2.12"
+		"twoslash": "^0.2.12",
+		"expressive-code": "^0.38.3"
 	},
 	"devDependencies": {
 		"@types/uglify-js": "^3.17.5",

--- a/packages/twoslash/package.json
+++ b/packages/twoslash/package.json
@@ -40,11 +40,11 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"expressive-code": "^0.38.3",
 		"mdast-util-from-markdown": "^2.0.2",
 		"mdast-util-gfm": "^3.0.0",
 		"mdast-util-to-hast": "^13.2.0",
-		"twoslash": "^0.2.12",
-		"expressive-code": "^0.38.3"
+		"twoslash": "^0.2.12"
 	},
 	"devDependencies": {
 		"@types/uglify-js": "^3.17.5",

--- a/packages/twoslash/src/styles.ts
+++ b/packages/twoslash/src/styles.ts
@@ -282,6 +282,33 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
             white-space: pre-wrap;
         }
 
+        .twoslash-popup-code,
+        .twoslash-popup-code span {
+            white-space: preserve !important;
+        }
+
+        .twoslash-popup-code-type {
+            color: ${cssVar("twoSlash.titleColor")} !important;
+            font-family: ${cssVar("codeFontFamily")};
+            font-weight: 600;
+        }
+
+        .twoslash-popup-code-type .frame pre {
+            display: contents !important;
+        }
+
+        .twoslash-popup-code-type .frame .ec-line .code {
+            padding-inline-start: 0 !important;
+        }
+
+        .twoslash-popup-code-type .frame pre > code {
+            padding: 0 !important;
+        }
+
+        .twoslash-popup-code-type .frame .header::before {
+            border: none !important;
+        }
+
         .twoslash-popup-code::-webkit-scrollbar,
         .twoslash-popup-code::-webkit-scrollbar-track,
         .twoslash-popup-docs::-webkit-scrollbar,
@@ -335,14 +362,9 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
             font-weight: 500;
         }
 
-        .twoslash-popup-code,
-        .twoslash-popup-code span {
-            white-space: preserve !important;
-        }
-
         .twoslash-popup-docs pre {
             width: 100%;
-            background-color: ${cssVar("twoSlash.background")} !important;
+            background-color: var(--ec-frm-edBg) !important;
             padding: .15rem;
             border-radius: 4px !important;
             position: relative !important;
@@ -350,12 +372,6 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
             display: inline-block !important;
             line-height: 1 !important;
             border: 2px solid ${cssVar("twoSlash.borderColor")} !important;
-        }
-
-        .twoslash-popup-code-type {
-            color: ${cssVar("twoSlash.titleColor")} !important;
-            font-family: ${cssVar("codeFontFamily")};
-            font-weight: 600;
         }
 
         .twoslash-popup-docs.twoslash-popup-docs-tags {
@@ -381,7 +397,7 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
 
         .twoslash-popup-docs code {
             margin: 0 !important;
-            background-color: transparent !important;
+            background-color: var(--ec-frm-edBg) !important;
             line-height: normal !important;
         }
 

--- a/packages/twoslash/src/types.ts
+++ b/packages/twoslash/src/types.ts
@@ -135,3 +135,8 @@ export type CompletionIcons = {
 export type CompletionIcon = keyof typeof completionIcons;
 
 export type TwoslashTag = "annotate" | "log" | "warn" | "error";
+
+export type RenderJSDocs = {
+	docs: Element | never[];
+	tags: Element | never[];
+};

--- a/playground/astro.config.mts
+++ b/playground/astro.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
 		starlight({
 			title: "Starlight",
 			expressiveCode: {
-				themes: ['github-dark-dimmed'],
+				// themes: ['github-dark-dimmed'],
 				plugins: [ectwoslash()],
 			},
 		}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@expressive-code/core':
         specifier: ^0.38.3
         version: 0.38.3
+      expressive-code:
+        specifier: ^0.38.3
+        version: 0.38.3
       mdast-util-from-markdown:
         specifier: ^2.0.2
         version: 2.0.2


### PR DESCRIPTION
This pull request introduces significant changes to the `twoslash` package, focusing on integrating Expressive Code for better code block rendering and simplifying the handling of annotations. The most important changes include the addition of Expressive Code dependencies, refactoring of annotation classes, and updates to helper functions to support the new rendering system.

### Integration of Expressive Code:

* [`packages/twoslash/package.json`](diffhunk://#diff-c82d37826e7a067e8c3ec9b11b7a2e91fce9cdda0f3298f8cfcd6bf3ab5c0a70L48-R47): Added `expressive-code` as a dependency.
* [`packages/twoslash/src/index.ts`](diffhunk://#diff-395ea5ffd5246ba1561f6dbdebff36bc6462dd94e845488a72c6801f9ed3d680R29): Integrated Expressive Code into the `ecTwoSlash` function for rendering code blocks and annotations. [[1]](diffhunk://#diff-395ea5ffd5246ba1561f6dbdebff36bc6462dd94e845488a72c6801f9ed3d680R29) [[2]](diffhunk://#diff-395ea5ffd5246ba1561f6dbdebff36bc6462dd94e845488a72c6801f9ed3d680L95-R106)

### Refactoring of Annotation Classes:

* [`packages/twoslash/src/annotations/hover.ts`](diffhunk://#diff-39994e970f6aab0bc5f7be978897c59dc6a1e424db6c7b4299e02f1b340c682bL28-R22): Refactored `TwoslashHoverAnnotation` to use `renderType` and `renderJSDocs` for rendering hover information and documentation. [[1]](diffhunk://#diff-39994e970f6aab0bc5f7be978897c59dc6a1e424db6c7b4299e02f1b340c682bL28-R22) [[2]](diffhunk://#diff-39994e970f6aab0bc5f7be978897c59dc6a1e424db6c7b4299e02f1b340c682bL66-R50)
* [`packages/twoslash/src/annotations/static.ts`](diffhunk://#diff-b214075e108e8603ff518713a944394f8a1eda23a7af58bd7295da7bbbf6181cL35-R29): Refactored `TwoslashStaticAnnotation` similarly to the hover annotation class. [[1]](diffhunk://#diff-b214075e108e8603ff518713a944394f8a1eda23a7af58bd7295da7bbbf6181cL35-R29) [[2]](diffhunk://#diff-b214075e108e8603ff518713a944394f8a1eda23a7af58bd7295da7bbbf6181cL77-R61)

### Updates to Helper Functions:

* [`packages/twoslash/src/helpers.ts`](diffhunk://#diff-3e3eb478cddd127f90f89a75a9adf7580ca0d0f729ef7bfbc8d58a7f33965bc5R142-R212): Added new functions `renderMarkdownWithCodeBlocks`, `renderMDInline`, `renderJSDocs`, and `renderType` to handle markdown processing and rendering with Expressive Code. [[1]](diffhunk://#diff-3e3eb478cddd127f90f89a75a9adf7580ca0d0f729ef7bfbc8d58a7f33965bc5R142-R212) [[2]](diffhunk://#diff-3e3eb478cddd127f90f89a75a9adf7580ca0d0f729ef7bfbc8d58a7f33965bc5R526-R569)

### Code Cleanup:

* `packages/twoslash/src/annotations/hover.ts` and `packages/twoslash/src/annotations/static.ts`: Removed redundant helper imports and functions. [[1]](diffhunk://#diff-39994e970f6aab0bc5f7be978897c59dc6a1e424db6c7b4299e02f1b340c682bL7-R7) [[2]](diffhunk://#diff-b214075e108e8603ff518713a944394f8a1eda23a7af58bd7295da7bbbf6181cL6-R9)

### Styling Updates:

* [`packages/twoslash/src/styles.ts`](diffhunk://#diff-0665159f1cb86018c1dc4b63b5b6660d76f5074b6952a8067a698b4c9cd03a90R285-R311): Added new CSS rules to style the rendered code blocks and annotations.
