### PR TITLE
Fix box shadow on twoslash code type info section

### DIFF
--- a/.changeset/shy-dingos-cover.md
+++ b/.changeset/shy-dingos-cover.md
@@ -1,0 +1,5 @@
+---
+"expressive-code-twoslash": patch
+---
+
+Fix box shadow on twoslash code type info section

--- a/packages/twoslash/src/styles.ts
+++ b/packages/twoslash/src/styles.ts
@@ -293,6 +293,10 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
             padding: 0 !important;
         }
 
+        .twoslash-popup-code-type .frame {
+            box-shadow: none !important;
+        }
+
         .twoslash-popup-code-type .frame .header::before {
             border: none !important;
         }


### PR DESCRIPTION
This pull request includes changes to fix the box shadow issue on the twoslash code type info section. The most important changes include updating the styles in the `styles.ts` file and documenting the change in the changeset file.

Fixes to box shadow issue:

* [`.changeset/shy-dingos-cover.md`](diffhunk://#diff-0472bd31ec9066121e7f7b10a0da592c277a34f92a9fba3330ac05eae25891ccR1-R5): Added a patch note to document the fix for the box shadow on the twoslash code type info section.
* [`packages/twoslash/src/styles.ts`](diffhunk://#diff-0665159f1cb86018c1dc4b63b5b6660d76f5074b6952a8067a698b4c9cd03a90R296-R299): Updated the `getTwoSlashBaseStyles` function to remove the box shadow from the `.twoslash-popup-code-type .frame` class.