### PR TITLE
Remove frame box shadow from docs popup

### DIFF
--- a/.changeset/strong-forks-live.md
+++ b/.changeset/strong-forks-live.md
@@ -1,0 +1,5 @@
+---
+"expressive-code-twoslash": patch
+---
+
+Remove frame box shadow from docs popup

--- a/packages/twoslash/src/styles.ts
+++ b/packages/twoslash/src/styles.ts
@@ -297,6 +297,10 @@ export function getTwoSlashBaseStyles({ cssVar }: ResolverContext): string {
             box-shadow: none !important;
         }
 
+        .twoslash-popup-docs .frame {
+            box-shadow: none !important;
+        }
+
         .twoslash-popup-code-type .frame .header::before {
             border: none !important;
         }


### PR DESCRIPTION
This pull request includes changes to remove the frame box shadow from the documentation popup in the `twoslash` package. The most important changes include adding a new style rule to remove the box shadow and updating the changeset file to reflect this modification.

Styling updates:

* [`packages/twoslash/src/styles.ts`](diffhunk://#diff-0665159f1cb86018c1dc4b63b5b6660d76f5074b6952a8067a698b4c9cd03a90R300-R303): Added a new CSS rule to remove the box shadow from the `.twoslash-popup-docs .frame` class.

Changeset updates:

* [`.changeset/strong-forks-live.md`](diffhunk://#diff-bca27c4d7cc563ae2b4faa656f01f7b094893d57f13118c8bf1f91f34abb29baR1-R5): Updated the changeset to document the removal of the frame box shadow from the docs popup.
