### PR TITLE
Refactor package.json: Move expressive-code to peerDependencies

### DIFF
--- a/.changeset/sharp-snails-work.md
+++ b/.changeset/sharp-snails-work.md
@@ -1,0 +1,5 @@
+---
+"expressive-code-twoslash": patch
+---
+
+Move expressive-code from a normal dependency to a peerDependency

--- a/packages/twoslash/package.json
+++ b/packages/twoslash/package.json
@@ -31,9 +31,7 @@
 		"default": "./dist/index.js"
 	},
 	"types": "./dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build-js-module": "tsm --require=../../scripts/filter-warnings.cjs ./scripts/minify.ts",
 		"compile": "tsup ./src/index.ts --format esm --dts --sourcemap --clean",
@@ -42,7 +40,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"expressive-code": "^0.38.3",
 		"mdast-util-from-markdown": "^2.0.2",
 		"mdast-util-gfm": "^3.0.0",
 		"mdast-util-to-hast": "^13.2.0",
@@ -54,6 +51,7 @@
 	},
 	"peerDependencies": {
 		"@expressive-code/core": "^0.38.3",
+		"expressive-code": "^0.38.3",
 		"typescript": "^5.5"
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `twoslash` package to adjust dependencies and update the project configuration. The most important changes include moving `expressive-code` from a normal dependency to a peer dependency and updating the `package.json` file accordingly.

Dependency adjustments:

* [`.changeset/sharp-snails-work.md`](diffhunk://#diff-e93c25b8a18dedd729538ca5c7e4671243c46f5d448cf1a59eb66b195df94b2aR1-R5): Added a changeset file to document the move of `expressive-code` from a normal dependency to a peer dependency.
* [`packages/twoslash/package.json`](diffhunk://#diff-c82d37826e7a067e8c3ec9b11b7a2e91fce9cdda0f3298f8cfcd6bf3ab5c0a70L45): Removed `expressive-code` from the `dependencies` section and added it to the `peerDependencies` section. [[1]](diffhunk://#diff-c82d37826e7a067e8c3ec9b11b7a2e91fce9cdda0f3298f8cfcd6bf3ab5c0a70L45) [[2]](diffhunk://#diff-c82d37826e7a067e8c3ec9b11b7a2e91fce9cdda0f3298f8cfcd6bf3ab5c0a70R54)

Project configuration updates:

* [`packages/twoslash/package.json`](diffhunk://#diff-c82d37826e7a067e8c3ec9b11b7a2e91fce9cdda0f3298f8cfcd6bf3ab5c0a70L34-R34): Reformatted the `files` array for consistency.