### PR TITLE
chore: configure dynamic site URL in astro.config.mts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,9 +27,10 @@
 	"cSpell.words": [
 		"Adammatthiesen",
 		"astrojs",
-		"codepaths",
 		"automations",
+		"codepaths",
 		"describedby",
+		"DOKPLOY",
 		"ectwoslash",
 		"esbuild",
 		"Hippotastic",

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -1,9 +1,16 @@
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
+// Define the Site URL
+const site = process.env.DOKPLOY_DEPLOY_URL
+	? `https://${process.env.DOKPLOY_DEPLOY_URL}`
+	: "https://twoslash.studiocms.dev/";
+
+const ogImageUrl = new URL("/og.png", site).href;
+
 // https://astro.build/config
 export default defineConfig({
-	site: "https://twoslash.studiocms.dev",
+	site,
 	integrations: [
 		starlight({
 			title: "Expressive Code Twoslash",
@@ -121,7 +128,7 @@ export default defineConfig({
 					tag: "meta",
 					attrs: {
 						property: "og:image",
-						content: "https://twoslash.studiocms.dev/og-image.png",
+						content: ogImageUrl,
 					},
 				},
 
@@ -144,7 +151,7 @@ export default defineConfig({
 					tag: "meta",
 					attrs: {
 						name: "twitter:image",
-						content: "https://twoslash.studiocms.dev/og-image.png",
+						content: ogImageUrl,
 					},
 				},
 			],


### PR DESCRIPTION
This pull request updates the documentation site configuration to support dynamic site URLs based on deployment environments, ensuring that Open Graph and Twitter images use the correct URL. It also adds new spelling words to the VSCode settings.

Configuration improvements for deployment environments:

* [`docs/astro.config.mts`](diffhunk://#diff-4919135145bb2f879825a0e1035443ac45a54466c6efe2756da1c7f6b5bb9ed4R4-R13): Introduced dynamic site URL assignment using the `DOKPLOY_DEPLOY_URL` environment variable, allowing the site to adapt to different deployment targets.
* [`docs/astro.config.mts`](diffhunk://#diff-4919135145bb2f879825a0e1035443ac45a54466c6efe2756da1c7f6b5bb9ed4L124-R131): Updated Open Graph and Twitter image meta tags to use a dynamically generated image URL based on the deployment environment, ensuring correct image links for previews. [[1]](diffhunk://#diff-4919135145bb2f879825a0e1035443ac45a54466c6efe2756da1c7f6b5bb9ed4L124-R131) [[2]](diffhunk://#diff-4919135145bb2f879825a0e1035443ac45a54466c6efe2756da1c7f6b5bb9ed4L147-R154)

Development tooling:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L30-R33): Added "DOKPLOY" to the spelling dictionary and reordered entries for consistency.