### PR TITLE
Correct GitHub links in astro.config.mts

### DIFF
--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -33,7 +33,7 @@ export default defineConfig({
 			social: [
 				{
 					label: "GitHub",
-					href: "https://github.com/withstudiocms/express-code-twoslash/",
+					href: "https://github.com/withstudiocms/expressive-code-twoslash/",
 					icon: "github",
 				},
 				{
@@ -58,7 +58,7 @@ export default defineConfig({
 				},
 			],
 			editLink: {
-				baseUrl: "https://github.com/withstudiocms/express-code-twoslash/edit/main/docs/",
+				baseUrl: "https://github.com/withstudiocms/expressive-code-twoslash/edit/main/docs/",
 			},
 			customCss: ["./src/styles/starlight.css"],
 			head: [


### PR DESCRIPTION
This pull request updates the GitHub URLs in the documentation site configuration to use the correct repository name, ensuring that links point to the intended project.

Repository URL updates:

* Updated the GitHub social link URL in `docs/astro.config.mts` to use `expressive-code-twoslash` instead of `express-code-twoslash`.
* Updated the edit link base URL in `docs/astro.config.mts` to use `expressive-code-twoslash` instead of `express-code-twoslash`.